### PR TITLE
Fix calendar break on null value

### DIFF
--- a/src/app/completed-components/calendar/calendar.component.html
+++ b/src/app/completed-components/calendar/calendar.component.html
@@ -38,7 +38,7 @@
                 *ngIf="!day.isOutOfMonth || displayOtherMonthDays"
   
                 [class.current]="day.isToday"
-                [class.selected]="selectedDate.ISODate === day.ISODate"
+                [class.selected]="selectedDate.showSelected && selectedDate.ISODate === day.ISODate"
                 [class.disabled]="day.isOutOfMonth"
   
                 materializeRipple

--- a/src/app/completed-components/calendar/calendar.component.ts
+++ b/src/app/completed-components/calendar/calendar.component.ts
@@ -53,14 +53,16 @@ export class CalendarComponent implements OnInit, OnChanges {
   }
 
   init() {
-    const isToday = this.isTodayDate(this.date);
-    const month = this.date.getMonth();
-    const year = this.date.getFullYear();
+    const dateExists = (typeof this.date !== 'undefined' && this.date !== null);
+    const openDate = dateExists ? this.date : new Date();
+    const isToday = this.isTodayDate(openDate);
+    const month = openDate.getMonth();
+    const year = openDate.getFullYear();
 
     this.weeks = this.fillWeeks(month, year);
     this.years = this.fillYears(year);
 
-    this.selectedDate = this.createDateModel(this.date, false, isToday);
+    this.selectedDate = this.createDateModel(openDate, false, isToday, dateExists);
   }
 
   getDayLabels(dayLabels: DayLabels): Array<DateLabel> {
@@ -92,7 +94,7 @@ export class CalendarComponent implements OnInit, OnChanges {
     ];
   }
 
-  createDateModel(date: Date, isOutOfMonth: boolean, isToday: boolean): DateModel {
+  createDateModel(date: Date, isOutOfMonth: boolean, isToday: boolean, showSelected: boolean): DateModel {
     const weekDay = date.getDay();
     const month = date.getMonth();
 
@@ -102,7 +104,8 @@ export class CalendarComponent implements OnInit, OnChanges {
       dayLabel: this.dayLabels[weekDay],
       isOutOfMonth: isOutOfMonth,
       isToday: isToday,
-      monthLabel: this.monthLabels[month]
+      monthLabel: this.monthLabels[month],
+      showSelected: showSelected
     };
 
     return dateModel;
@@ -172,7 +175,7 @@ export class CalendarComponent implements OnInit, OnChanges {
     const isToday = this.isTodayDate(date);
     const isOutOfMonth = (dayNumber <= 0 || date > finalMonthDay);
 
-    return this.createDateModel(date, isOutOfMonth, isToday);
+    return this.createDateModel(date, isOutOfMonth, isToday, true);
   }
 
   showPrevMonth() {
@@ -237,7 +240,7 @@ export class CalendarComponent implements OnInit, OnChanges {
 
       this.date = this.createDateObject(day, month, year);
       this.showYears = false;
-      this.selectedDate = this.createDateModel(this.date, false, true);
+      this.selectedDate = this.createDateModel(this.date, false, true, true);
 
       this.weeks = this.fillWeeks(month, year);
     }, this.selectYearAnimationDuration);

--- a/src/app/completed-components/calendar/calendar.model.ts
+++ b/src/app/completed-components/calendar/calendar.model.ts
@@ -11,6 +11,7 @@ export interface DateModel {
   isToday: boolean;
   isOutOfMonth: boolean;
   monthLabel: DateLabel;
+  showSelected: boolean;
 }
 
 export interface MonthModel {

--- a/src/app/modules/home/home.component.html
+++ b/src/app/modules/home/home.component.html
@@ -213,6 +213,8 @@ Calendar that displays other month days
 <materialize-calendar></materialize-calendar>
 Calendar with value
 <materialize-calendar [date]="date"></materialize-calendar>
+Calendar without a selected value
+<materialize-calendar [date]="null"></materialize-calendar>
 
 <br />
 <br />
@@ -228,8 +230,10 @@ Datepicker disabled
 <materialize-datepicker [disabled]="true"></materialize-datepicker>
 Datepicker disabled with FloatLabel
 <materialize-datepicker [disabled]="true" floatLabel="Float Label"></materialize-datepicker>
-Datepicker disabled with FloatLabel and value
-<materialize-datepicker [disabled]="true" floatLabel="Float Label" value="10-01-2019"></materialize-datepicker>
+Datepicker with FloatLabel and null value
+<materialize-datepicker floatLabel="Float Label" [inputValue]="null"></materialize-datepicker>
+Datepicker with FloatLabel and value
+<materialize-datepicker floatLabel="Float Label" [inputValue]="date"></materialize-datepicker>
 Datepicker Full size
 <materialize-datepicker [fullSize]="true"></materialize-datepicker>
 Datepicker Custom Format


### PR DESCRIPTION
## Description
Calendar accepts null as date input value.

## Motivation and Context
You may want to show a calendar with no selected date.
On the other hand, calendar is used in datepicker. There is a possibility that the date input might be required and so the initial date must be null to make sure the user inputs a date manually instead of starting in today's date.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] The PR title is no longer than 64 characters.
- [X] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features, new releases and breaking changes).
- [X] My code follows the code style of this project.
- [ ] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [X] I've added new examples (applies to new features and breaking changes in core library)
