### PR TITLE
Added click event on slider option.

### DIFF
--- a/src/app/completed-components/button/button.model.ts
+++ b/src/app/completed-components/button/button.model.ts
@@ -22,5 +22,6 @@ export enum BUTTON_LEVELS {
 
 export enum BUTTON_TYPES {
   BUTTON = 'button',
-  SUBMIT = 'submit'
+  SUBMIT = 'submit',
+  RESET = 'reset'
 }

--- a/src/app/completed-components/slider/slider-option/slider-option.component.html
+++ b/src/app/completed-components/slider/slider-option/slider-option.component.html
@@ -1,6 +1,7 @@
 <div [ngClass]="[prefix + '-slider-option-container', className]"
   [class.active]="isActive"
 
+  (click)="onClick()"
   #template>
   <ng-content></ng-content>
 </div>

--- a/src/app/completed-components/slider/slider-option/slider-option.component.ts
+++ b/src/app/completed-components/slider/slider-option/slider-option.component.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://raw.githubusercontent.com/workylab/materialize-angular/master/LICENSE
  */
 
-import { Component, ElementRef, Input, ViewChild } from '@angular/core';
+import { Component, ElementRef, EventEmitter, Input, Output, ViewChild } from '@angular/core';
 import { config } from '../../../config';
 import { SliderOptionModel } from './slider-option.model';
 
@@ -25,10 +25,17 @@ export class SliderOptionComponent implements SliderOptionModel {
   @Input() className: string = SliderOptionComponent.defaultProps.className;
   @Input() value: number | string | boolean | null = SliderOptionComponent.defaultProps.value;
 
+  @Output('onClick') onClickEmitter: EventEmitter<number | string | boolean | null>;
+
   public prefix = config.components.prefix;
   public isActive: boolean;
 
   constructor() {
     this.isActive = false;
+    this.onClickEmitter = new EventEmitter();
+  }
+
+  onClick() {
+    this.onClickEmitter.emit(this.value);
   }
 }

--- a/src/app/completed-components/slider/slider.component.ts
+++ b/src/app/completed-components/slider/slider.component.ts
@@ -77,6 +77,7 @@ export class SliderComponent implements AfterContentInit, AfterViewInit, Control
     this.actionDown = this.actionDown.bind(this);
     this.actionMove = this.actionMove.bind(this);
     this.actionUp = this.actionUp.bind(this);
+    this.onOptionClick = this.onOptionClick.bind(this);
     this.update = this.update.bind(this);
 
     window.addEventListener(this.supportedEvents.resize, this.update);
@@ -94,9 +95,23 @@ export class SliderComponent implements AfterContentInit, AfterViewInit, Control
 
   update() {
     setTimeout(() => {
+      this.registerEventOptions();
       this.renderPositions();
       this.moveToValue(this.value, false);
     }, 0);
+  }
+
+  registerEventOptions() {
+    this.options.forEach(option => {
+      option.onClickEmitter.subscribe(this.onOptionClick);
+    });
+  }
+
+  onOptionClick(value: number | string | boolean | null) {
+    this.value = value;
+    this.onChangeEmitter.emit(this.value);
+    this.onChange(this.value);
+    this.moveToValue(this.value, true);
   }
 
   renderPositions() {

--- a/src/styles/modules/slider/slider-option.styles.scss
+++ b/src/styles/modules/slider/slider-option.styles.scss
@@ -8,6 +8,7 @@
 
 .#{$materialize-prefix}-slider-option-container {
   color: $materialize-slider-option-color;
+  cursor: $materialize-slider-option-cursor;
   font-family: $materialize-slider-option-font-family;
   font-size: $materialize-slider-option-font-size;
   font-weight: $materialize-slider-option-font-weight;

--- a/src/styles/modules/slider/slider-option.variables.scss
+++ b/src/styles/modules/slider/slider-option.variables.scss
@@ -7,6 +7,7 @@
  */
 
 $materialize-slider-option-color: map-get($theme-colors, 'gray-20') !default;
+$materialize-slider-option-cursor: pointer !default;
 $materialize-slider-option-font-family: $theme-font-family-primary !default;
 $materialize-slider-option-font-size: $theme-font-size-md !default;
 $materialize-slider-option-font-weight: $theme-font-weight-regular !default;


### PR DESCRIPTION
## Description
Click event when slider option is being clicked was added.

This updates the slider indicator position when the event is fired.

## Motivation and Context
There was not way to update the slider indicator position when the option was clicked.

## How Has This Been Tested?
It was tested on local environment and the documentation was updated with this new change as well.



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] The PR title is no longer than 64 characters.
- [x] The PR is submitted to the correct branch (`master` for bug fixes, `dev` for new features, new releases and breaking changes).
- [x] My code follows the code style of this project.
- [x] I've added relevant changes to the documentation (applies to new features and breaking changes in core library)
- [ ] I've added new examples (applies to new features and breaking changes in core library)
